### PR TITLE
add user parameters for setting robot state

### DIFF
--- a/pyb_utils/collision.py
+++ b/pyb_utils/collision.py
@@ -91,8 +91,12 @@ class CollisionDetector:
         """
 
         # put the robot in the given configuration
-        for i in range(pyb.getNumJoints(self.robot_id, physicsClientId=self.col_id)):
-            pyb.resetJointState(self.robot_id, i, q[i], physicsClientId=self.col_id)
+        for i in range(
+            pyb.getNumJoints(self.robot_id, physicsClientId=self.col_id)
+        ):
+            pyb.resetJointState(
+                self.robot_id, i, q[i], physicsClientId=self.col_id
+            )
 
         # compute shortest distances between all object pairs
         distances = []

--- a/pyb_utils/ghost.py
+++ b/pyb_utils/ghost.py
@@ -11,6 +11,7 @@ class GhostObject:
     to that body, or it can be positioned at an absolute location in the world
     frame.
     """
+
     def __init__(
         self,
         visual_uid,
@@ -105,6 +106,7 @@ class GhostObject:
 
 class GhostSphere(GhostObject):
     """Spherical ghost object."""
+
     def __init__(
         self,
         radius,

--- a/pyb_utils/robots.py
+++ b/pyb_utils/robots.py
@@ -4,6 +4,7 @@ import pybullet as pyb
 
 class Robot:
     """Wrapper for a PyBullet robot."""
+
     def __init__(self, uid):
         """Initialize using the uid of the robot."""
         self.uid = uid

--- a/scripts/collision_detection_example.py
+++ b/scripts/collision_detection_example.py
@@ -46,22 +46,6 @@ def load_environment(client_id):
     }
     return bodies
 
-def create_user_debug_params(gui_id):
-    return {
-        'collision_margin': pyb.addUserDebugParameter('collision_margin', 0, 0.2, 0.01, physicsClientId=gui_id),
-        'lbr_iiwa_joint1': pyb.addUserDebugParameter('lbr_iiwa_joint1', -2*np.pi, 2*np.pi, 0, physicsClientId=gui_id),
-        'lbr_iiwa_joint2': pyb.addUserDebugParameter('lbr_iiwa_joint2', -2*np.pi, 2*np.pi, 0, physicsClientId=gui_id),
-        'lbr_iiwa_joint3': pyb.addUserDebugParameter('lbr_iiwa_joint3', -2*np.pi, 2*np.pi, 0, physicsClientId=gui_id),
-        'lbr_iiwa_joint4': pyb.addUserDebugParameter('lbr_iiwa_joint4', -2*np.pi, 2*np.pi, 0, physicsClientId=gui_id),
-        'lbr_iiwa_joint5': pyb.addUserDebugParameter('lbr_iiwa_joint5', -2*np.pi, 2*np.pi, 0, physicsClientId=gui_id),
-        'lbr_iiwa_joint6': pyb.addUserDebugParameter('lbr_iiwa_joint6', -2*np.pi, 2*np.pi, 0, physicsClientId=gui_id),
-        'lbr_iiwa_joint7': pyb.addUserDebugParameter('lbr_iiwa_joint7', -2*np.pi, 2*np.pi, 0, physicsClientId=gui_id)
-    }
-
-def update_robot_state(robot_id, state, physicsClientId):
-    for joint_idx in range(pyb.getNumJoints(robot_id, physicsClientId=physicsClientId)):
-        pyb.resetJointState(robot_id, joint_idx, state[joint_idx], physicsClientId=physicsClientId)
-
 def create_robot_debug_params(gui_id, robot_id):
     params = dict()
 
@@ -76,7 +60,6 @@ def create_robot_debug_params(gui_id, robot_id):
         )
 
     return params
-
 
 def read_robot_state(robot_id, robot_params, physicsClientId):
     state = np.array(
@@ -135,9 +118,6 @@ def main():
     # simulation server only used for collision detection
     col_id = pyb.connect(pyb.DIRECT)
 
-    # create user debug parameters
-    user_params = create_user_debug_params(gui_id)
-
     # add bodies to both of the environments
     bodies = load_environment(gui_id)
     collision_bodies = load_environment(col_id)
@@ -172,7 +152,6 @@ def main():
 
     while True:
         # compute shortest distances for a random configuration
-<<<<<<< HEAD
         state = read_robot_state(robot_id, robot_params, gui_id)
 
         d = col_detector.compute_distances(state)
@@ -182,36 +161,13 @@ def main():
 
         if not in_col:
             update_robot_state(robot_id, state, physicsClientId=gui_id)
-=======
-        q = np.array([
-            pyb.readUserDebugParameter(user_params["lbr_iiwa_joint1"]),
-            pyb.readUserDebugParameter(user_params["lbr_iiwa_joint2"]),
-            pyb.readUserDebugParameter(user_params["lbr_iiwa_joint3"]),
-            pyb.readUserDebugParameter(user_params["lbr_iiwa_joint4"]),
-            pyb.readUserDebugParameter(user_params["lbr_iiwa_joint5"]),
-            pyb.readUserDebugParameter(user_params["lbr_iiwa_joint6"]),
-            pyb.readUserDebugParameter(user_params["lbr_iiwa_joint7"])
-        ])
-        
-        d = col_detector.compute_distances(q)
-        in_col = col_detector.in_collision(
-            q, 
-            margin=pyb.readUserDebugParameter(user_params["collision_margin"]))
-
-        if not in_col:
-            update_robot_state(robot_id, q, physicsClientId=gui_id)
->>>>>>> 4160cbbaabeef3b169ebfdc3d6d36177c622ac7d
         else:
             pyb.addUserDebugText(
                 "Avoiding collision",
                 textPosition=[0, 0, 1.5],
                 textColorRGB=[1, 0, 0],
                 textSize=2,
-<<<<<<< HEAD
                 lifeTime=0.2,
-=======
-                lifeTime=0.2
->>>>>>> 4160cbbaabeef3b169ebfdc3d6d36177c622ac7d
             )
 
         print(f"Distance to obstacles = {d}")


### PR DESCRIPTION
Fixes adamheins/pyb_utils#1

## Features added:
1. User debug parameters for all the joints of robot arm (7 joints, min: -2pi, max: 2pi, default: 0).
2. User debug parameter to set collision margin (min: 0; max: 0.2; default: 0.01).
3. Update robot in GUI only if the robot is not within collision margin with any object.
4. Display a short message on the GUI if robot is within collision margin. Disappears in 0.2 secs once robot is out of collision.

## Feature demo images:
### User Debug Parameters
Allows to set arbitrary joint values for the 7 robot joints via GUI sliders. Also allows to set collision margin from the GUI.
![image](https://user-images.githubusercontent.com/55598261/193356615-4d0584bb-5491-4f24-bd98-4da07a9c3d23.png)

### Message when robot in collision margin
Invalid joint configurations can be set using the sliders but only valid configurations are updated on the GUI. A Message on GUI indicates robot is within collision margin with an object. The message disappears in 0.2 secs once the robot is out of collision.
![image](https://user-images.githubusercontent.com/55598261/193356833-598d8a63-6280-4a6a-b641-db797c630e47.png)

